### PR TITLE
Ensure matplot window is closed at program exit and stabilize

### DIFF
--- a/imdbtop250.py
+++ b/imdbtop250.py
@@ -45,6 +45,9 @@ plt.xlabel('year')
 plt.ylabel('number of movies in the top 250')
 plt.tick_params(axis='x', which='major', labelsize=6)
 plt.tight_layout()
+fig_manager = plt.get_current_fig_manager()
+if hasattr(fig_manager, 'window'):  # on mac osx window property does not exist
+    fig_manager.window.showMaximized()
 plt.show(block=False)
 
 print(raw_input("Press enter to close"))

--- a/imdbtop250.py
+++ b/imdbtop250.py
@@ -21,7 +21,6 @@ for result in results:
 df = pd.DataFrame(listy, columns=['number','title','year'])
 df.to_csv('movielist.csv',index=False,encoding='utf-8')
 print(df)
-print(input("Press enter to close"))
 
 x = []
 
@@ -46,10 +45,8 @@ plt.xlabel('year')
 plt.ylabel('number of movies in the top 250')
 plt.tick_params(axis='x', which='major', labelsize=6)
 plt.tight_layout()
-mng = plt.get_current_fig_manager()
-mng.resize(*mng.window.maxsize())
-plt.show()
+plt.show(block=False)
 
+print(raw_input("Press enter to close"))
 
-
-
+plt.close('all')


### PR DESCRIPTION
Previously, the matplot window wasn't closed down correctly at
program exit. Resizing the window to max is not working on mac
osx. Here both issues are fixed and we wait for the user after
showing the window. Moreover, the EOF exception is avoid by
using raw_input in stead of input.